### PR TITLE
docs: add WebSocket close code specification

### DIFF
--- a/docs/api/websocket.en.md
+++ b/docs/api/websocket.en.md
@@ -227,6 +227,23 @@ WebSocket connections and messages are subject to rate limiting:
 
 > 📖 **Detailed Guide**: [Rate Limiting Guide](../development/rate-limit.md)
 
+## Close Codes
+
+List of close codes returned by the server when terminating a WebSocket connection. Clients should use these codes to determine whether to reconnect.
+
+| Close Code | Name | Description | Reconnect |
+|-----------|------|-------------|-----------|
+| `1000` | Normal Closure | Graceful shutdown | Optional |
+| `1008` | Policy Violation | Authentication failure (missing token, expired token, invalid token, missing `sub` claim) | :x: Do NOT reconnect — refresh token first |
+| `1011` | Internal Error | Server internal error | :white_check_mark: Retry with exponential backoff |
+| `4029` | Rate Limit Exceeded | Connection rate limit exceeded (default: 10 per 60s) | :white_check_mark: Retry with exponential backoff |
+
+!!! tip "Frontend Implementation Guide"
+    - **`1008` (Auth failure)**: Do NOT reconnect. Retrying with an expired token causes unnecessary server load. Refresh the token before reconnecting.
+    - **`4029` (Rate limit)**: Reconnect with exponential backoff.
+    - **`1011` (Server error)**: Reconnect with exponential backoff.
+    - **`1000` (Normal closure)**: Server intentionally closed the connection. Reconnect if needed.
+
 ## Reconnection
 
 It's recommended to implement automatic reconnection:
@@ -249,16 +266,24 @@ class TimerWebSocket {
     );
 
     this.ws.onclose = (event) => {
-      if (event.code === 4029) {
-        // Rate limit - exponential backoff
+      if (event.code === 1008) {
+        // Auth failure - do NOT reconnect, refresh token first
+        console.error('Authentication failed:', event.reason);
+        this.onAuthFailure?.(event.reason);
+        return;
+      }
+
+      if (this.reconnectAttempts >= this.maxReconnectAttempts) return;
+
+      if (event.code === 4029 || event.code === 1011) {
+        // Rate limit or server error - exponential backoff
         const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 60000);
         setTimeout(() => this.connect(), delay);
-        this.reconnectAttempts++;
-      } else if (this.reconnectAttempts < this.maxReconnectAttempts) {
-        // Normal disconnect - reconnect
+      } else {
+        // Other disconnect - reconnect
         setTimeout(() => this.connect(), 1000);
-        this.reconnectAttempts++;
       }
+      this.reconnectAttempts++;
     };
 
     this.ws.onopen = () => {

--- a/docs/api/websocket.ko.md
+++ b/docs/api/websocket.ko.md
@@ -227,6 +227,23 @@ WebSocket 연결과 메시지는 Rate Limiting이 적용됩니다:
 
 > 📖 **상세 가이드**: [Rate Limiting 가이드](../development/rate-limit.ko.md)
 
+## Close Codes
+
+서버가 WebSocket 연결을 종료할 때 반환하는 close code 목록입니다. 클라이언트는 이 코드를 기반으로 재연결 여부를 판단해야 합니다.
+
+| Close Code | 이름 | 설명 | 재연결 |
+|-----------|------|------|--------|
+| `1000` | Normal Closure | 정상 종료 | 선택적 |
+| `1008` | Policy Violation | 인증 실패 (토큰 누락, 토큰 만료, 무효 토큰, `sub` 클레임 누락) | :x: 재연결 금지 — 토큰 갱신 후 재시도 |
+| `1011` | Internal Error | 서버 내부 오류 | :white_check_mark: 지수 백오프 후 재시도 |
+| `4029` | Rate Limit Exceeded | 연결 Rate Limit 초과 (기본: 60초당 10회) | :white_check_mark: 지수 백오프 후 재시도 |
+
+!!! tip "프론트엔드 구현 가이드"
+    - **`1008` (인증 실패)**: 재연결하지 마세요. 만료된 토큰으로 반복 연결을 시도하면 서버에 불필요한 부하가 발생합니다. 토큰을 갱신한 후 재연결하세요.
+    - **`4029` (Rate Limit)**: 지수 백오프(exponential backoff)를 적용하여 재연결하세요.
+    - **`1011` (서버 오류)**: 지수 백오프를 적용하여 재연결하세요.
+    - **`1000` (정상 종료)**: 서버가 의도적으로 연결을 종료한 경우입니다. 필요에 따라 재연결하세요.
+
 ## 재연결
 
 자동 재연결 구현을 권장합니다:
@@ -249,16 +266,24 @@ class TimerWebSocket {
     );
 
     this.ws.onclose = (event) => {
-      if (event.code === 4029) {
-        // Rate limit - 지수 백오프
+      if (event.code === 1008) {
+        // 인증 실패 - 재연결 금지, 토큰 갱신 필요
+        console.error('인증 실패:', event.reason);
+        this.onAuthFailure?.(event.reason);
+        return;
+      }
+
+      if (this.reconnectAttempts >= this.maxReconnectAttempts) return;
+
+      if (event.code === 4029 || event.code === 1011) {
+        // Rate limit 또는 서버 오류 - 지수 백오프
         const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 60000);
         setTimeout(() => this.connect(), delay);
-        this.reconnectAttempts++;
-      } else if (this.reconnectAttempts < this.maxReconnectAttempts) {
-        // 정상 연결 해제 - 재연결
+      } else {
+        // 기타 연결 해제 - 재연결
         setTimeout(() => this.connect(), 1000);
-        this.reconnectAttempts++;
       }
+      this.reconnectAttempts++;
     };
 
     this.ws.onopen = () => {


### PR DESCRIPTION
## Summary
- WebSocket close code 스펙을 한국어/영어 API 문서에 추가 (`1000`, `1008`, `1011`, `4029`)
- 각 close code별 재연결 여부 및 프론트엔드 구현 가이드 포함
- 재연결 예제 코드에 `1008` (인증 실패) 시 재연결 차단 로직 추가

## Test plan
- [ ] `docs/api/websocket.ko.md` 렌더링 확인
- [ ] `docs/api/websocket.en.md` 렌더링 확인
- [ ] 프론트엔드 팀에서 close code 스펙 기반 재연결 로직 검증

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)