### PR TITLE
chore: add Dependabot config for pip, docker, github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  # Python 의존성 (requirements.txt — pip-compile 락파일 자동 인식)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    # 공급망 공격 방어: 갓 릴리스된 버전은 일정 기간 숙성 후 PR 생성.
+    # 단, 보안(CVE) 업데이트는 cooldown 적용 제외 → 즉시 PR.
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    groups:
+      # patch/minor 업데이트는 하나의 PR로 묶어 노이즈 감소
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Dockerfile 베이스 이미지 (python:3.14-slim)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    commit-message:
+      prefix: "chore"
+
+  # GitHub Actions 버전 (actions/checkout@v4 등)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
@
## Change Log

### Dependabot 자동 의존성 업데이트 도입
- `.github/dependabot.yml` 신규 추가
- 기존 주간 Docker 빌드는 베이스 이미지를 리빌드할 뿐, **고정된(`==`) Python 의존성의 CVE는 자동으로 해결하지 못함**. 이를 보완하기 위해 Dependabot으로 의존성/베이스 이미지/액션 업데이트 PR을 자동 생성하도록 구성.

### 대상 생태계 (3종)
- **pip** — `requirements.txt` (pip-compile 락파일 자동 인식, 갱신 시 형식 유지)
- **docker** — `Dockerfile`의 베이스 이미지 `python:3.14-slim`
- **github-actions** — 워크플로우 액션 버전 (`actions/checkout@v4` 등)

### 주요 설정
- **스케줄**: 매주 월요일 (기존 주간 Docker 빌드와 동일 리듬, `Asia/Seoul` 09:00)
- **groups**: pip의 minor/patch 업데이트를 단일 PR로 묶어 노이즈 감소 (major는 개별 PR)
- **cooldown**: 갓 릴리스된 버전을 숙성 기간(patch 7일 / minor 14일 / major 30일) 후 PR 생성하여 공급망 공격 방어
  - **단, 보안(CVE) 업데이트는 cooldown 제외 → 즉시 PR**
- **commit-message.prefix**: 레포 Conventional Commits 규칙에 맞춰 `chore` / `ci` 접두사 적용

### 활성화 후 권장 사항
- 레포 Settings → Dependabot security updates 토글 활성화 시 CVE 보안 PR 즉시 생성

## Issue Number
N/A

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
@