### PR TITLE
chore: group docker and github-actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,10 @@ updates:
       timezone: "Asia/Seoul"
     commit-message:
       prefix: "chore"
+    groups:
+      docker-all:
+        patterns:
+          - "*"
 
   # GitHub Actions 버전 (actions/checkout@v4 등)
   - package-ecosystem: "github-actions"
@@ -47,3 +51,8 @@ updates:
       timezone: "Asia/Seoul"
     commit-message:
       prefix: "ci"
+    # 액션 버전 업데이트는 모두 단일 PR로 묶어 PR 한도(기본 5) 초과 방지
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
@
## Change Log

### Dependabot PR 한도 초과 문제 해결
- github-actions 생태계가 PR 한도(기본 5개)에 도달하여 "Dependabot cannot open any more pull requests" 발생
  - 현재 개별 PR 5개 오픈 중: #22~#26 (모두 액션 버전 업)
- **원인**: github-actions / docker 생태계에 그룹 설정이 없어 업데이트마다 개별 PR이 생성됨

### 변경 내용
- `docker`, `github-actions` 생태계에 `groups` 추가 (`patterns: ["*"]`)
  - 해당 생태계의 모든 업데이트를 **단일 PR로 묶어** PR 한도 초과 방지 및 노이즈 감소
- 이미 pip에 적용된 그룹화 정책과 동일한 방향

### 머지 후 동작
- 다음 Dependabot 실행 시 개별 액션 PR(#22~#26)이 **닫히고 묶음 PR 1개로 대체**됨
- 또는 기존 5개 PR을 먼저 머지/클로즈해도 무방

## Issue Number
N/A

## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
@