### PR TITLE
docs: document strict Content-Type requirement for JSON requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+
+- **Strict `Content-Type` checking for JSON requests**: As part of the FastAPI dependency upgrade (0.132+, via [#29](https://github.com/onprem-hipster-timer/backend/pull/29)), requests carrying a JSON body must include a `Content-Type: application/json` header. A missing header now returns `422 Unprocessable Entity`, and an incorrect media type returns `415 Unsupported Media Type`; bodyless requests (`GET`, `DELETE`) are unaffected. The previous lenient behavior can be restored with `FastAPI(strict_content_type=False)`. Documented in the API Overview (Korean and English).
 
 ---
 

--- a/docs/api/overview.en.md
+++ b/docs/api/overview.en.md
@@ -92,6 +92,16 @@ Common HTTP status codes:
 - **Dates**: ISO 8601 format (`2024-01-15T10:00:00Z`)
 - **UUIDs**: Standard UUID v4 format
 
+!!! warning "JSON requests require the `Content-Type` header"
+    Requests that carry a body (`POST`, `PUT`, `PATCH`) must include the `Content-Type: application/json` header.
+
+    - **Missing header** → `422 Unprocessable Entity` (the body is not parsed as JSON)
+    - **Wrong type** (e.g. `text/plain`) → `415 Unsupported Media Type`
+    - `application/json` and `application/*+json` media types are accepted.
+    - Bodyless requests (`GET`, `DELETE`, etc.) are unaffected.
+
+    Most HTTP clients (`fetch`, `axios`, `httpx`, ...) set this header automatically when sending JSON, but you must set it explicitly when sending a raw body (e.g. `curl --data`). (This strict check is enabled by default since FastAPI 0.132.)
+
 ## Interactive Documentation (Test Links)
 
 When running the local dev server, you can test the API at these URLs:

--- a/docs/api/overview.ko.md
+++ b/docs/api/overview.ko.md
@@ -92,6 +92,16 @@ CRUD 작업을 위한 전통적인 RESTful 엔드포인트:
 - **날짜**: ISO 8601 형식 (`2024-01-15T10:00:00Z`)
 - **UUID**: 표준 UUID v4 형식
 
+!!! warning "JSON 요청에는 `Content-Type` 헤더가 필수입니다"
+    본문을 포함하는 요청(`POST`, `PUT`, `PATCH`)은 반드시 `Content-Type: application/json` 헤더를 포함해야 합니다.
+
+    - **헤더 누락** → `422 Unprocessable Entity` (본문이 JSON으로 파싱되지 않음)
+    - **잘못된 타입**(예: `text/plain`) → `415 Unsupported Media Type`
+    - `application/json` 및 `application/*+json` 계열이 허용됩니다.
+    - 본문이 없는 요청(`GET`, `DELETE` 등)은 영향받지 않습니다.
+
+    `fetch`, `axios`, `httpx` 등 대부분의 HTTP 클라이언트는 JSON 전송 시 이 헤더를 자동으로 설정하지만, `curl --data`처럼 본문만 수동으로 보내는 경우 헤더를 직접 지정해야 합니다. (이 엄격한 검사는 FastAPI 0.132부터 기본 활성화되었습니다.)
+
 ## 대화형 문서 (테스트 링크)
 
 로컬 개발 서버 실행 시 아래 주소로 접속해 API를 테스트할 수 있습니다.


### PR DESCRIPTION
@
## Change Log

### `strict_content_type` 동작 문서화
FastAPI 0.132부터 JSON 요청에 대한 엄격한 `Content-Type` 검사가 기본 활성화됩니다. 이 동작 변경은 **테스트로는 드러나지 않으므로**(TestClient의 `json=`이 헤더를 자동 설정) API 소비자를 위해 명시적으로 문서화합니다.

- `docs/api/overview.ko.md` / `docs/api/overview.en.md` — "데이터 형식 / Data Formats" 섹션에 admonition 추가
  - **헤더 누락** → `422 Unprocessable Entity`
  - **잘못된 타입** → `415 Unsupported Media Type`
  - 본문 없는 요청(`GET`, `DELETE`)은 영향 없음
  - opt-out: `FastAPI(strict_content_type=False)`
- `CHANGELOG.md` — `[Unreleased] > Changed` 항목 추가 (FastAPI 업그레이드 #29 연계)

### ⚠️ 머지 순서 주의
이 동작은 **FastAPI 0.132+로 올라가는 [#29](https://github.com/onprem-hipster-timer/backend/pull/29)가 머지되어야 실제로 적용**됩니다. 따라서 이 문서 PR은 **#29와 함께 또는 그 이후에 머지**하는 것을 권장합니다. (먼저 머지되면 문서가 아직 적용 안 된 동작을 설명하는 짧은 불일치 구간이 생깁니다.)

상태 코드/도입 버전은 FastAPI 0.132 릴리스 노트 1차 출처로 확인했습니다.

## Issue Number
N/A

## Checklist
- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
@