### PR TITLE
fix: pin uvloop with non-Windows marker so lockfiles install on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Fixed
+
+- **Cross-platform lockfile (Windows installability)**: `uvloop` (a `uvicorn[standard]` transitive dependency with no Windows wheel) was pinned without an environment marker, so `pip install -r requirements.txt` failed on Windows with `uvloop does not support Windows`. `uvloop` is now declared directly in `requirements.in` with a `; sys_platform != 'win32'` marker, which pip-compile preserves in the lockfile and Dependabot retains across regenerations (it reads but never rewrites `requirements.in`). Linux/production installs are unchanged. Verified: fresh Windows venv install succeeds (uvloop skipped); Linux test suite still passes (824 tests).
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1033,6 +1033,23 @@ pip-compile requirements.in
 pip-sync requirements.txt
 ```
 
+#### 크로스 플랫폼 마커 (Windows 호환성)
+
+lockfile은 Linux에서 컴파일됩니다(로컬 Docker 및 Dependabot). 그래서 플랫폼별 간접 의존성이
+**환경 마커 없이** 고정될 수 있는데, 이러면 다른 플랫폼에서 `pip install`이 깨집니다. 대표적인
+예가 **`uvloop`**(`uvicorn[standard]`가 가져옴)으로, Windows 휠이 없어 마커 없는 `uvloop==…`
+고정은 Windows 설치 시 `uvloop does not support Windows` 오류로 실패합니다.
+
+모든 플랫폼에서 설치가 되도록, 이런 패키지는 **`requirements.in`에 마커와 함께 직접 선언**합니다:
+
+```
+uvloop ; sys_platform != 'win32'
+```
+
+pip-compile은 `.in`의 명시적 마커를 생성된 `.txt`에 유지하고, Dependabot은 `requirements.in`을
+읽기만 하고 수정하지 않으므로 마커가 모든 재생성에서 살아남습니다. `--universal`로도 마커를
+넣을 수 있지만 Dependabot이 이 플래그를 보존하지 않으므로, 마커는 `requirements.in`에 두어야 합니다.
+
 #### pip-tools를 사용하는 이유
 
 - **재현 가능한 빌드**: 고정된 버전으로 일관된 환경 보장

--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,26 @@ pip-compile requirements.in
 pip-sync requirements.txt
 ```
 
+#### Cross-platform markers (Windows compatibility)
+
+The lockfiles are compiled on Linux (locally via Docker and by Dependabot), so a platform-specific
+transitive dependency may be pinned **without** an environment marker — which breaks `pip install`
+on other platforms. The clearest case is **`uvloop`** (pulled by `uvicorn[standard]`): it has no
+Windows wheel, so a bare `uvloop==…` pin makes Windows installs fail with
+`uvloop does not support Windows`.
+
+To keep installs working everywhere, such packages are declared **directly in `requirements.in`
+with an explicit marker**:
+
+```
+uvloop ; sys_platform != 'win32'
+```
+
+pip-compile preserves explicit `.in` markers in the generated `.txt`, and Dependabot reads (but
+never rewrites) `requirements.in` — so the marker survives every regeneration. `--universal` would
+also emit markers, but Dependabot does **not** preserve that flag, so the marker must live in
+`requirements.in`.
+
 #### Why pip-tools?
 
 - **Reproducible builds**: Pinned versions ensure consistent environments

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -283,7 +283,7 @@ urllib3==2.6.3
     # via requests
 uvicorn[standard]==0.48.0
     # via -r requirements.txt
-uvloop==0.22.1
+uvloop==0.22.1 ; sys_platform != "win32"
     # via
     #   -r requirements.txt
     #   uvicorn

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,11 @@
 # Core Framework
 fastapi
 uvicorn[standard]  # WebSocket 지원 포함
+# uvicorn[standard]의 전이 의존성 uvloop은 Windows 미지원(휠 없음)이라 그냥 두면 로컬
+# Windows에서 sdist 빌드 실패로 설치가 깨진다. 직접 선언 + 마커로 제외해 크로스 플랫폼
+# 설치를 가능하게 한다. pip-compile은 .in의 명시적 마커를 출력에 유지하고, Dependabot은
+# --universal을 보존하지 않으므로 마커는 .in에 둔다. (Linux 프로덕션은 uvloop 그대로 사용)
+uvloop ; sys_platform != 'win32'
 starlette
 
 # Database

--- a/requirements.txt
+++ b/requirements.txt
@@ -132,8 +132,10 @@ tzdata==2026.2
     # via -r requirements.in
 uvicorn[standard]==0.48.0
     # via -r requirements.in
-uvloop==0.22.1
-    # via uvicorn
+uvloop==0.22.1 ; sys_platform != "win32"
+    # via
+    #   -r requirements.in
+    #   uvicorn
 watchfiles==1.1.1
     # via uvicorn
 websockets==16.0


### PR DESCRIPTION
@
## Change Log

### 문제
로컬 Windows `.venv`에서 `pip install -r requirements.txt`(또는 `-dev`)가 실패:
```
RuntimeError: uvloop does not support Windows at the moment
ERROR: Failed to build uvloop ...
```
lockfile이 Linux(로컬 Docker·Dependabot)에서 컴파일되면서, `uvicorn[standard]`의 전이 의존성 `uvloop`이 **환경 마커 없이** 고정됨. Windows에는 uvloop 휠이 없어 sdist 빌드를 시도하다 실패.

### 수정
- `requirements.in`에 uvloop를 **직접 선언 + 마커**로 추가:
  ```
  uvloop ; sys_platform != win32
  ```
- lockfile 재생성 결과: `uvloop==0.22.1 ; sys_platform != "win32"` (prod·dev 양쪽). **버전 변경 0건**, 마커만 추가.

### 왜 `.in` 마커인가 (durability)
- pip-compile은 `.in`의 명시적 마커를 출력 lockfile에 보존한다 (jazzband/pip-tools#460).
- **Dependabot은 `--universal`을 보존하지 않는다** — 파일 *내용*에서 플래그를 재구성(`--generate-hashes`/`--allow-unsafe`/`--strip-extras` 등)하며 `--universal`은 감지 대상이 아님. 따라서 `--universal`로 고치면 다음 pip PR에서 되돌아감.
- 반면 Dependabot은 `requirements.in`을 **읽기만** 하고 수정하지 않으므로, `.in`에 둔 마커는 모든 재생성에서 살아남음. → 비-universal Linux 재컴파일을 2회 돌려 마커 유지 확인.

### colorama
- 별도 조치 불필요. pip가 Windows 설치 시 `click`의 Windows 마커로 colorama를 자동 해결하며(검증에서 colorama 0.4.6 설치 확인), dev lockfile에는 `mkdocs-material`로 이미 무조건 포함됨.

### 검증
- ✅ **Windows**: 새 venv에서 `requirements.txt` + `requirements-dev.txt` 설치 성공(`EXIT=0`), uvloop은 설치 목록에서 제외됨.
- ✅ **Linux 패리티**: `Dockerfile.test` 빌드 후 전체 스위트 **824 passed**.
- ✅ **버전 변경 없음**: diff는 uvloop 마커 추가뿐.
- ✅ **Dependabot durability**: 비-universal 재컴파일에서 마커 유지.

### 문서
- `README.md` / `README.ko.md`의 pip-tools 섹션에 "크로스 플랫폼 마커" 설명 추가.

## Issue Number
N/A

## Checklist
- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
@