### PR TITLE
chore: migrate authlib.jose to joserfc (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+
+- **`authlib.jose` → `joserfc` migration**: OIDC JWT verification in `app/core/auth.py` was migrated off the deprecated `authlib.jose` module (deprecated since Authlib 1.7.0, slated for removal in Authlib 2.0.0) to the standalone `joserfc` package, which Authlib already pulls in transitively. JWKS loading (`KeySet.import_key_set`), decoding + claim validation (`jwt.decode` + `JWTClaimsRegistry`), and error handling (`joserfc.errors.JoseError`) were ported with no behavioral change to token verification. Signature verification is now restricted to asymmetric algorithms (`RS256/384/512`, `ES256/384/512`), preventing the `alg` confusion / `none` attacks that Authlib's unrestricted default allowed. `authlib` was dropped from `requirements.in` (and the lockfiles) in favor of a direct `joserfc` dependency. ([#34](https://github.com/onprem-hipster-timer/backend/issues/34), [#37](https://github.com/onprem-hipster-timer/backend/pull/37))
 
 ---
 

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,16 +1,18 @@
 """
 OIDC 인증 모듈
 
-Authlib를 사용한 OIDC discovery 및 JWT Access Token 검증.
+joserfc를 사용한 OIDC discovery 및 JWT Access Token 검증.
 모든 API 엔드포인트를 보호하고 CurrentUser 컨텍스트를 제공합니다.
 """
 import logging
 from typing import Any
 
 import httpx
-from authlib.jose import JsonWebKey, jwt
-from authlib.jose.errors import JoseError
 from cachetools import TTLCache
+from joserfc import jwt
+from joserfc.errors import JoseError
+from joserfc.jwk import KeySet
+from joserfc.jwt import JWTClaimsRegistry
 from fastapi import Depends, HTTPException, Request, Response, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
@@ -22,6 +24,12 @@ logger = logging.getLogger(__name__)
 
 # HTTP Bearer 스키마
 security = HTTPBearer(auto_error=False)
+
+# 허용 서명 알고리즘 (비대칭만 허용 — alg 혼동/none 공격 방지)
+ALLOWED_JWT_ALGORITHMS = ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"]
+
+# JWT 표준 클레임(exp/nbf/iat) 검증 레지스트리
+_claims_registry = JWTClaimsRegistry()
 
 
 class CurrentUser(BaseModel):
@@ -83,12 +91,12 @@ class OIDCClient:
         logger.info(f"OIDC metadata loaded from {self.discovery_url}")
         return metadata
 
-    async def get_jwks(self) -> JsonWebKey:
+    async def get_jwks(self) -> KeySet:
         """
         JWKS (JSON Web Key Set) 조회 (캐싱됨)
-        
+
         Returns:
-            Authlib JsonWebKey 객체
+            joserfc KeySet 객체
         """
         cache_key = "jwks"
         if cache_key in self._jwks_cache:
@@ -104,7 +112,7 @@ class OIDCClient:
             response.raise_for_status()
             jwks_data = response.json()
 
-        jwks = JsonWebKey.import_key_set(jwks_data)
+        jwks = KeySet.import_key_set(jwks_data)
         self._jwks_cache[cache_key] = jwks
         logger.info(f"JWKS loaded from {jwks_uri}")
         return jwks
@@ -125,11 +133,12 @@ class OIDCClient:
         try:
             jwks = await self.get_jwks()
 
-            # JWT 디코딩 및 서명 검증
-            claims = jwt.decode(token, jwks)
+            # JWT 디코딩 및 서명 검증 (허용된 비대칭 알고리즘만)
+            decoded = jwt.decode(token, jwks, algorithms=ALLOWED_JWT_ALGORITHMS)
+            claims = decoded.claims
 
-            # 클레임 검증
-            claims.validate()
+            # 표준 클레임(exp/nbf/iat) 검증
+            _claims_registry.validate(claims)
 
             # issuer 검증
             if claims.get("iss") != settings.OIDC_ISSUER_URL:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,8 +24,6 @@ anyio==4.12.1
     #   watchfiles
 asyncpg==0.31.0
     # via -r requirements.txt
-authlib==1.7.2
-    # via -r requirements.txt
 babel==2.17.0
     # via mkdocs-material
 backrefs==6.1
@@ -69,7 +67,6 @@ cross-web==0.7.0
 cryptography==48.0.0
     # via
     #   -r requirements.txt
-    #   authlib
     #   joserfc
 fastapi==0.136.3
     # via -r requirements.txt
@@ -112,9 +109,7 @@ jinja2==3.1.6
     #   mkdocs
     #   mkdocs-material
 joserfc==1.7.1
-    # via
-    #   -r requirements.txt
-    #   authlib
+    # via -r requirements.txt
 mako==1.3.10
     # via
     #   -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ aiosqlite
 psycopg2-binary
 
 # Authentication
-authlib
+joserfc  # authlib.jose deprecation 대응 (authlib → joserfc 마이그레이션, #34)
 cryptography
 
 # HTTP Client

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,6 @@ anyio==4.12.1
     #   watchfiles
 asyncpg==0.31.0
     # via -r requirements.in
-authlib==1.7.2
-    # via -r requirements.in
 cachetools==7.1.1
     # via -r requirements.in
 certifi==2026.1.4
@@ -36,7 +34,6 @@ cross-web==0.7.0
 cryptography==48.0.0
     # via
     #   -r requirements.in
-    #   authlib
     #   joserfc
 fastapi==0.136.3
     # via -r requirements.in
@@ -61,7 +58,7 @@ idna==3.11
 jinja2==3.1.6
     # via -r requirements.in
 joserfc==1.7.1
-    # via authlib
+    # via -r requirements.in
 mako==1.3.10
     # via alembic
 markupsafe==3.0.3

--- a/tests/core/test_auth.py
+++ b/tests/core/test_auth.py
@@ -9,11 +9,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-from authlib.jose import jwt
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
+from joserfc import jwt
+from joserfc.jwk import KeySet, RSAKey
 
 
 # ============================================================================
@@ -40,8 +41,7 @@ def generate_rsa_keypair():
     )
 
     # JWKS 형태로 공개키 변환
-    from authlib.jose import JsonWebKey
-    jwk = JsonWebKey.import_key(public_pem, {"kty": "RSA", "use": "sig", "kid": "test-key-id"})
+    jwk = RSAKey.import_key(public_pem, parameters={"use": "sig", "kid": "test-key-id"})
     jwks = {"keys": [jwk.as_dict()]}
 
     return private_pem, public_pem, jwks
@@ -78,8 +78,9 @@ def create_test_token(
         claims.update(extra_claims)
 
     header = {"alg": "RS256", "kid": "test-key-id"}
-    token = jwt.encode(header, claims, TEST_PRIVATE_KEY)
-    return token.decode() if isinstance(token, bytes) else token
+    private_key = RSAKey.import_key(TEST_PRIVATE_KEY)
+    token = jwt.encode(header, claims, private_key, algorithms=["RS256"])
+    return token
 
 
 # ============================================================================
@@ -308,7 +309,6 @@ class TestOIDCClient:
     async def test_verify_token_valid(self):
         """유효한 토큰 검증 성공"""
         from app.core.auth import OIDCClient
-        from authlib.jose import JsonWebKey
 
         # 유효한 토큰 생성
         token = create_test_token(
@@ -325,7 +325,7 @@ class TestOIDCClient:
             client = OIDCClient()
 
             # get_jwks를 mock하여 테스트용 JWKS 반환
-            jwks = JsonWebKey.import_key_set(TEST_JWKS)
+            jwks = KeySet.import_key_set(TEST_JWKS)
             with patch.object(client, "get_jwks", new_callable=AsyncMock) as mock_get_jwks:
                 mock_get_jwks.return_value = jwks
 
@@ -339,7 +339,6 @@ class TestOIDCClient:
     async def test_verify_token_invalid_issuer(self):
         """잘못된 issuer의 토큰 검증 실패"""
         from app.core.auth import OIDCClient
-        from authlib.jose import JsonWebKey
 
         # 잘못된 issuer로 토큰 생성
         token = create_test_token(
@@ -355,7 +354,7 @@ class TestOIDCClient:
 
             client = OIDCClient()
 
-            jwks = JsonWebKey.import_key_set(TEST_JWKS)
+            jwks = KeySet.import_key_set(TEST_JWKS)
             with patch.object(client, "get_jwks", new_callable=AsyncMock) as mock_get_jwks:
                 mock_get_jwks.return_value = jwks
 
@@ -369,7 +368,6 @@ class TestOIDCClient:
     async def test_verify_token_invalid_audience(self):
         """잘못된 audience의 토큰 검증 실패"""
         from app.core.auth import OIDCClient
-        from authlib.jose import JsonWebKey
 
         # 잘못된 audience로 토큰 생성
         token = create_test_token(
@@ -385,7 +383,7 @@ class TestOIDCClient:
 
             client = OIDCClient()
 
-            jwks = JsonWebKey.import_key_set(TEST_JWKS)
+            jwks = KeySet.import_key_set(TEST_JWKS)
             with patch.object(client, "get_jwks", new_callable=AsyncMock) as mock_get_jwks:
                 mock_get_jwks.return_value = jwks
 
@@ -399,7 +397,6 @@ class TestOIDCClient:
     async def test_verify_token_expired(self):
         """만료된 토큰 검증 실패"""
         from app.core.auth import OIDCClient
-        from authlib.jose import JsonWebKey
 
         # 만료된 토큰 생성
         token = create_test_token(
@@ -416,7 +413,7 @@ class TestOIDCClient:
 
             client = OIDCClient()
 
-            jwks = JsonWebKey.import_key_set(TEST_JWKS)
+            jwks = KeySet.import_key_set(TEST_JWKS)
             with patch.object(client, "get_jwks", new_callable=AsyncMock) as mock_get_jwks:
                 mock_get_jwks.return_value = jwks
 


### PR DESCRIPTION
## Change Log

### 배경
`authlib.jose`는 **Authlib 1.7.0부터 deprecated**(import 시 `AuthlibDeprecationWarning`)되었고 **Authlib 2.0.0에서 제거 예정**입니다. 의존성 그룹 업그레이드([#29](https://github.com/onprem-hipster-timer/backend/pull/29))로 authlib가 1.7.2로 올라가며 경고가 활성화되고, 동시에 후속 패키지 `joserfc`가 전이 의존성으로 이미 설치됩니다. OIDC JWT 검증을 `joserfc`로 옮겨 deprecation에 선제 대응합니다.

### 변경 사항
사용처는 `app/core/auth.py` 한 곳(순수 resource server의 로컬 JWT 검증)에 집중되어 있습니다.
- **JWKS 로드**: `JsonWebKey.import_key_set` → joserfc `KeySet.import_key_set`.
- **디코딩/검증**: `jwt.decode` + `claims.validate()` → joserfc `jwt.decode` + `JWTClaimsRegistry`. claims는 `decoded.claims`(dict)로 추출하며, issuer/audience 수동 검증 로직은 그대로 유지.
- **예외 처리**: `authlib.jose.errors.JoseError` → `joserfc.errors.JoseError` (만료→`ExpiredTokenError`, 서명 오류→`BadSignatureError` 모두 하위 클래스라 401 처리 동일).
- **의존성**: `requirements.in`에서 `authlib` 제거, `joserfc` 직접 선언. authlib는 코드 어디에도 안 쓰여 완전히 제거(joserfc·cryptography는 authlib가 끌어오던 것이라 그대로 유지).

### 동작 변경 (보안 강화)
- 검증 알고리즘을 **비대칭(`RS256/384/512`, `ES256/384/512`)으로 제한**. 기존 authlib 기본값은 제약이 없어 `alg` 혼동/`none` 공격 표면이 있었음. OIDC 표준(RS256)은 그대로 통과하고 토큰 검증 결과 자체는 동일.

### 검증
- ✅ `tests/core/test_auth.py` **24 passed** (joserfc 1.7.1 로컬 설치) — RSA 키 생성·JWKS·유효/만료/잘못된 issuer·audience 경로 포함.
- ✅ `tests/core` **39 passed**, `import app.main` 정상.
- ✅ `grep -rni authlib app/ tests/` — 잔존 `authlib.jose` 사용처 없음(남은 건 `requirements.in` 주석뿐).
- ✅ **lockfile 정합성**: WSL Ubuntu에서 `pip-compile`(Python 3.13, Linux)로 prod·dev 양쪽 재생성 → 커밋된 lockfile과 **diff 0** (authlib 1줄 제거 외 패키지 변동 없음, joserfc/cryptography 유지).

### 문서
- `CHANGELOG.md` `[Unreleased] > Changed` 항목 추가. 신규 환경변수·API 변경이 없어 `docs/` 수정은 없음.

## Issue Number
#34

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
